### PR TITLE
Bug correction - commonChars

### DIFF
--- a/src/com/wcohen/ss/Jaro.java
+++ b/src/com/wcohen/ss/Jaro.java
@@ -63,7 +63,7 @@ public class Jaro extends AbstractStringDistance
 		for (int i=0; i<s.length(); i++) {
 			char ch = s.charAt(i);
 			boolean foundIt = false;
-			for (int j=Math.max(0,i-halflen); !foundIt && j<Math.min(i+halflen,t.length()); j++) {
+			for (int j=Math.max(0,i-halflen); !foundIt && j<Math.min(i+halflen+1,t.length()); j++) {
 				if (copy.charAt(j)==ch) {
 					foundIt = true;
 					common.append(ch);


### PR DESCRIPTION
At line 66, commonChars is looking for common characters between two strings. It is supposed to look for common chars at position "i" with a maximum displacement of "halflen", but "j" wont ever be "i+halflen". Adding a "+1" makes it work correctly.
To find out how this bug affects you, try calculating Jaro value of "gimenez" vs "gienezm".